### PR TITLE
PAYM-372: Android SDK - Option to turn off animations, or just use images

### DIFF
--- a/payroc-demo-app/src/main/java/com/payroc/payrocsdktestapp/MainActivity.kt
+++ b/payroc-demo-app/src/main/java/com/payroc/payrocsdktestapp/MainActivity.kt
@@ -55,6 +55,8 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
         setContentView(R.layout.activity_main)
         mainView = findViewById(R.id.main_content)
         PayrocSdk.layoutCheck(this)
+        PayrocSdk.merchantSettings.enable_background_animations =
+            PrefHelper.getPrefs(this).getBoolean(getString(com.payroc.sdk.R.string.shared_prefs_background_animation_enabled), true)
 
 //        if (savedInstanceState == null) {
 //            supportFragmentManager.beginTransaction()

--- a/payroc-demo-app/src/main/java/com/payroc/payrocsdktestapp/ui/tools/ToolsFragment.kt
+++ b/payroc-demo-app/src/main/java/com/payroc/payrocsdktestapp/ui/tools/ToolsFragment.kt
@@ -4,11 +4,14 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Switch
 import androidx.appcompat.widget.AppCompatButton
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProviders
 import com.payroc.android_core.PLog
+import com.payroc.android_core.helpers.PrefHelper
 import com.payroc.payrocsdktestapp.R
+import com.payroc.sdk.PayrocSdk
 
 class ToolsFragment : Fragment() {
 
@@ -18,10 +21,17 @@ class ToolsFragment : Fragment() {
     }
 
     private lateinit var viewModel: ToolsViewModel
+    private lateinit var enableBackgroundAnimation: Switch
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle? ): View {
 
         val view = inflater.inflate(R.layout.tools_fragment, container, false)
+        enableBackgroundAnimation = view.findViewById(R.id.background_anim_switch)
+        enableBackgroundAnimation.isChecked = PrefHelper.getPrefs(this.requireContext()).getBoolean(getString(com.payroc.sdk.R.string.shared_prefs_background_animation_enabled), true)
+        enableBackgroundAnimation.setOnCheckedChangeListener { buttonView, isChecked ->
+            PrefHelper.getPrefs(this.requireContext()).edit().putBoolean(getString(com.payroc.sdk.R.string.shared_prefs_background_animation_enabled), isChecked).apply()
+            PayrocSdk.merchantSettings.enable_background_animations = isChecked
+        }
 
         val emailSupport = view.findViewById<AppCompatButton>(R.id.toolsEmailSupport)
         emailSupport.setOnClickListener {

--- a/payroc-demo-app/src/main/res/layout/tools_fragment.xml
+++ b/payroc-demo-app/src/main/res/layout/tools_fragment.xml
@@ -31,4 +31,17 @@
             app:layout_constraintEnd_toEndOf="parent"
             android:layout_marginEnd="8dp" app:layout_constraintTop_toBottomOf="@+id/toolsEmailSupport"/>
 
+    <Switch
+        android:id="@+id/background_anim_switch"
+        style="@style/TextAppearance.AppCompat.Widget.Switch"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:text="@string/enable_background_anim"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/toolsCallSupport" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/payroc-demo-app/src/main/res/values/strings.xml
+++ b/payroc-demo-app/src/main/res/values/strings.xml
@@ -55,4 +55,6 @@
     <string name="transaction_status">Transaction Status</string>
     <string name="capture_all">Capture All</string>
     <string name="time_out">Time out</string>
+
+    <string name="enable_background_anim">Enable Background Animation</string>
 </resources>


### PR DESCRIPTION
- added switch "Enable Background Animation" on menu "Settings Page Tools" (here later can be added more Merchant/Style Settings such as enable sound/tip/surcharge)